### PR TITLE
Fixed a little clipping issue

### DIFF
--- a/src/css/jquery.flipster.css
+++ b/src/css/jquery.flipster.css
@@ -29,6 +29,9 @@
   -webkit-backface-visibility: hidden;
   -moz-backface-visibility: hidden;
   backface-visibility: hidden;
+  -webkit-box-sizing: content-box;
+  -moz-box-sizing: content-box;
+  box-sizing: content-box;
 }
 .flip-item {
   position: absolute;


### PR DESCRIPTION
![screen shot 2013-11-07 at 5 42 48 pm](https://f.cloud.github.com/assets/600699/1497476/0f4372cc-480f-11e3-95ca-c761ca760356.png)

I'm using bootstrap in my project and the box-sizing: border-box was causing the flipster reflections to be hidden, as well as clipping off the bottom corner of the next & previous items in the list
