### PR TITLE
Resize update only visibled

### DIFF
--- a/src/jquery.flipster.js
+++ b/src/jquery.flipster.js
@@ -326,8 +326,12 @@
             }
 
             function resize(skipTransition) {
-                if ( skipTransition ) { noTransition(); }
+                // don't update elements if _container is hidden
+                if (_container.is(':hidden')) {
+                    return false;
+                };
 
+                if ( skipTransition ) { noTransition(); }
                 _containerWidth = _container.width();
                 _container.height(calculateBiggestItemHeight());
 

--- a/src/jquery.flipster.js
+++ b/src/jquery.flipster.js
@@ -387,7 +387,11 @@
                     if ( !_containerWidth || _itemOffsets[_currentIndex] === undefined ) { resize(true); }
 
                     if ( transformSupport ) {
-                        _container.css('transform', 'translateX(' + _itemOffsets[_currentIndex] + 'px)');
+                        _container.css({
+                            'transform': 'translateX(' + _itemOffsets[_currentIndex] + 'px)',
+                            '-webkit-transform': 'translateX(' + _itemOffsets[_currentIndex] + 'px)',
+                            '-ms-transform': 'translateX(' + _itemOffsets[_currentIndex] + 'px)'
+                        });
                     } else {
                         _container.css({ 'left': _itemOffsets[_currentIndex] + 'px' });
                     }


### PR DESCRIPTION
If a container is hidden - images have width = 0 and the plugin die when try calculate new parameters on resize. This fix disable this problem. It will be better to move it to the additional parameter. 