### PR TITLE
Add passive event handler support for wheel scrolling

### DIFF
--- a/src/jquery.flipster.js
+++ b/src/jquery.flipster.js
@@ -576,12 +576,27 @@
                         }, 50));
 
                     // Disable mousewheel on window if event began in elem.
-                    $window.on('mousewheel.flipster wheel.flipster', function(e) {
-                        if ( _wheelInside ) {
-                            e.preventDefault();
-                            _wheelInside = false;
-                        }
-                    });
+                    var supportsPassive = false;
+                    try {
+                      window.addEventListener("test", null, Object.defineProperty({}, 'passive', {
+                        get: function () { supportsPassive = true; }
+                      }));
+                    } catch(e) {}
+                    var preventScroll = function (e) {
+                      if ( _wheelInside ) {
+                        e.preventDefault();
+                        _wheelInside = false;
+                      }
+                    }
+                    var wheelOpt = supportsPassive ? { passive: false } : false;
+                    window.addEventListener(
+                      'mousewheel',
+                      preventScroll,
+                      wheelOpt);
+                    window.addEventListener(
+                      'wheel',
+                      preventScroll,
+                      wheelOpt);
                 }
             }
 


### PR DESCRIPTION
Since jQuery doesn't support chrome's passive option in event handlers, I changed this to vanilla JS.
See [Google documentation](https://developers.google.com/web/updates/2016/06/passive-event-listeners)

The wheel scrolling for the whole page is now stopped if the pointer is over the flipster and throws no JS error anymore in chrome browser.
